### PR TITLE
Make canPlayerModifyAt respect claims

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ loader_version=0.11.6
 fabric_version=0.35.2+1.17
 
 # Mod Properties
-mod_version = 1.4.1-beta
+mod_version = 1.4.2-beta
 maven_group = com.github.draylar
 archives_base_name = get-off-my-lawn
 

--- a/src/main/java/draylar/goml/EventHandlers.java
+++ b/src/main/java/draylar/goml/EventHandlers.java
@@ -7,6 +7,7 @@ import draylar.goml.api.ClaimBox;
 import draylar.goml.api.ClaimUtils;
 import draylar.goml.api.PermissionReason;
 import draylar.goml.api.event.ClaimEvents;
+import draylar.goml.api.event.ModifyEvents;
 import draylar.goml.block.ClaimAnchorBlock;
 import draylar.goml.entity.ClaimAnchorBlockEntity;
 import net.fabricmc.fabric.api.event.player.*;
@@ -28,6 +29,7 @@ public class EventHandlers {
         registerInteractBlockCallback();
         registerAttackEntityCallback();
         registerInteractEntityCallback();
+        registerPlayerModifyCallback();
         registerAnchorAttackCallback();
     }
 
@@ -69,6 +71,13 @@ public class EventHandlers {
             ActionResult result = testPermission(claimsFound, player, Hand.MAIN_HAND, pos, PermissionReason.BLOCK_PROTECTED);
             return !result.equals(ActionResult.FAIL);
         });
+    }
+
+    private static void registerPlayerModifyCallback() {
+        ModifyEvents.PLAYER_MODIFY_AT.register(((world, player, pos) -> {
+            Selection<Entry<ClaimBox, Claim>> claimsFound = ClaimUtils.getClaimsAt(world, pos);
+            return testPermission(claimsFound, player, Hand.MAIN_HAND, pos, PermissionReason.BLOCK_PROTECTED);
+        }));
     }
 
     private static void registerAnchorAttackCallback() {

--- a/src/main/java/draylar/goml/api/event/ModifyEvents.java
+++ b/src/main/java/draylar/goml/api/event/ModifyEvents.java
@@ -1,0 +1,34 @@
+package draylar.goml.api.event;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+public class ModifyEvents {
+
+    /**
+     *  This callback is triggered when a player attempts to modify a block
+     *  Callback handlers can return deny this by not returning pass {@link ActionResult}.
+     */
+
+    public static final Event<PlayerModifyHandler> PLAYER_MODIFY_AT = EventFactory.createArrayBacked(PlayerModifyHandler.class,
+            (listeners) -> (world, player, pos) -> {
+                for (PlayerModifyHandler event : listeners) {
+                    ActionResult result = event.check(world, player, pos);
+
+                    if (result != ActionResult.PASS) {
+                        return result;
+                    }
+                }
+
+                return ActionResult.PASS;
+            }
+    );
+
+    public interface PlayerModifyHandler {
+        ActionResult check(World world, PlayerEntity player, BlockPos pos);
+    }
+}

--- a/src/main/java/draylar/goml/mixin/ServerWorldMixin.java
+++ b/src/main/java/draylar/goml/mixin/ServerWorldMixin.java
@@ -1,0 +1,26 @@
+package draylar.goml.mixin;
+
+import draylar.goml.api.event.ModifyEvents;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.math.BlockPos;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ServerWorld.class)
+public class ServerWorldMixin {
+
+    @Inject(at = @At("TAIL"), method="canPlayerModifyAt", cancellable = true)
+    public void canPlayerModifyAt(PlayerEntity player, BlockPos pos, CallbackInfoReturnable<Boolean> cir) {
+        if(cir.getReturnValue()) {
+            ServerWorld world = ((ServerWorld) (Object) this);
+
+            if (ModifyEvents.PLAYER_MODIFY_AT.invoker().check(world, player, pos) != ActionResult.PASS) {
+                cir.setReturnValue(false);
+            }
+        }
+    }
+}

--- a/src/main/resources/goml.mixins.json
+++ b/src/main/resources/goml.mixins.json
@@ -11,7 +11,8 @@
     "TntEntityMixin",
     "augment.EndermanEntityMixin",
     "augment.VillagerEntityMixin",
-    "compat.BlastExplosionMixin"
+    "compat.BlastExplosionMixin",
+    "ServerWorldMixin"
   ],
   "client": [
     "WorldRendererMixin"


### PR DESCRIPTION
This allows for third party mods to query whether or not a player can affect a block or not. Simplifying the support process.